### PR TITLE
Fix import instructions and update MCU-Driver-HAL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "MCU-Driver-HAL"]
 	path = MCU-Driver-HAL
-	url = git@github.com:MCU-Driver-HAL/MCU-Driver-HAL.git
+	url = https://github.com/MCU-Driver-HAL/MCU-Driver-HAL

--- a/sdfx_st/examples/README.md
+++ b/sdfx_st/examples/README.md
@@ -9,7 +9,7 @@ Each example build instructions provides access to hardware specific source code
 Each application can be built by doing the following:
 1. Clone the repository recursively to get the `MCU-Driver-HAL` submodule:
     ```
-    git clone --recursive git@github.com:ARMmbed/MCU-Driver-ST.git
+    git clone --recursive https://github.com/MCU-Driver-HAL/MCU-Driver-ST
     ```
 1. Change the current working directory to `MCU-Driver-ST/sdfx_st/examples/<INTERFACE>/`
 1. Run:
@@ -25,7 +25,7 @@ Each application can be built by doing the following:
 Outcome: The application compiles, links and produces artefacts.
 
 # Program the artefact
-From the create `MCU-Driver-ST/sdfx_st/examples/<INTERFACE>/cmake_build/`, copy the binary to the device with the following command:
+From `MCU-Driver-ST/sdfx_st/examples/<INTERFACE>/cmake_build/`, copy the binary to the device with the following command:
 ```
 cp sdfx-stm-example-<INTERFACE>.bin <MOUNT_POINT_PATH>
 ```


### PR DESCRIPTION
Fixed wrong links in docs when importing the repo.
Updated MCU-Driver-HAL to latest version that replaces ssh with http as dependency of Greentea submodule (https://github.com/MCU-Driver-HAL/MCU-Driver-HAL/pull/5)