### PR TITLE
Added a -GNinja flag to the build file generation step 

### DIFF
--- a/sdfx_st/tests/README.md
+++ b/sdfx_st/tests/README.md
@@ -21,7 +21,7 @@ Each test can be built by doing the following:
     cmake -S ./ -B cmake_build/ -GNinja -DGREENTEA_CLIENT_STDIO=OFF -DMBED_TOOLCHAIN=<TOOLCHAIN> -DCMAKE_BUILD_TYPE=debug
     ```
 
-    If you prefer to use the Ninja build system rather than the UNIX Makefiles, append `-G Ninja` to the command above.
+    If you prefer to use UNIX Makefiles rather than the Ninja build system, remove `-GNinja` from the command above.
 1. Build:
 
     ```

--- a/sdfx_st/tests/README.md
+++ b/sdfx_st/tests/README.md
@@ -18,7 +18,7 @@ Each test can be built by doing the following:
 1. Generate the build system files:
 
     ```
-    cmake -S ./ -B cmake_build/ -DGREENTEA_CLIENT_STDIO=OFF -DMBED_TOOLCHAIN=<TOOLCHAIN> -DCMAKE_BUILD_TYPE=debug
+    cmake -S ./ -B cmake_build/ -GNinja -DGREENTEA_CLIENT_STDIO=OFF -DMBED_TOOLCHAIN=<TOOLCHAIN> -DCMAKE_BUILD_TYPE=debug
     ```
 
     If you prefer to use the Ninja build system rather than the UNIX Makefiles, append `-G Ninja` to the command above.


### PR DESCRIPTION
Ideally located in the test build instructions, the build file generation step for running the tests doesn't include the -GNinja flag, while the same instruction for running an example program does.
Without this, it was causing issues with building on windows as Cmake would try and find Nmake (part of visual studio) which is not guaranteed to be present on a windows system, while Ninja should be present on a system that has been set up with all the mbed tools and dependencies. 