### PR TITLE
Enable CRC greentea test

### DIFF
--- a/sdfx_st/hal/CMakeLists.txt
+++ b/sdfx_st/hal/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(sdfx-hal-st
         src/hal_tick_overrides.c
         # src/i2c_api.c
         # src/lp_ticker.c
-        # src/mbed_crc_api.c
+        src/crc_api.c
         src/mbed_overrides.c
         src/ospi_api.c
         src/pinmap.c

--- a/sdfx_st/hal/src/crc_api.c
+++ b/sdfx_st/hal/src/crc_api.c
@@ -1,7 +1,7 @@
 #include "crc_api.h"
 #include "device.h"
 
-#include "platform/mbed_assert.h"
+#include "mbed_assert.h"
 
 #if DEVICE_CRC
 

--- a/sdfx_st/tests/mbed_hal/crc/CMakeLists.txt
+++ b/sdfx_st/tests/mbed_hal/crc/CMakeLists.txt
@@ -34,8 +34,3 @@ target_link_libraries(sdfx-st-test-crc
 )
 
 mbed_set_post_build(sdfx-st-test-crc)
-
-option(VERBOSE_BUILD "Have a verbose build process")
-if(VERBOSE_BUILD)
-    set(CMAKE_VERBOSE_MAKEFILE ON)
-endif()

--- a/sdfx_st/tests/mbed_hal/crc/CMakeLists.txt
+++ b/sdfx_st/tests/mbed_hal/crc/CMakeLists.txt
@@ -15,28 +15,25 @@
 
 cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
+project(sdfx-st-test-crc)
+
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../MCU-Driver-HAL CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../.mbedbuild CACHE INTERNAL "")
-
-set(TEST_TARGET sdfx-st-test-crc)
-set(TEST_TARGET_LIB sdfx-test-crc)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
 add_subdirectory(../../../.. ./MCU-Driver-ST)
 
-add_executable(${TEST_TARGET})
+add_executable(sdfx-st-test-crc)
 
-mbed_configure_app_target(${TEST_TARGET})
+mbed_configure_app_target(sdfx-st-test-crc)
 
-project(${TEST_TARGET})
-
-target_link_libraries(${TEST_TARGET}
+target_link_libraries(sdfx-st-test-crc
     PRIVATE
-        ${TEST_TARGET_LIB}
+        sdfx-test-crc
 )
 
-mbed_set_post_build(${TEST_TARGET})
+mbed_set_post_build(sdfx-st-test-crc)
 
 option(VERBOSE_BUILD "Have a verbose build process")
 if(VERBOSE_BUILD)

--- a/sdfx_st/tests/mbed_hal/crc/CMakeLists.txt
+++ b/sdfx_st/tests/mbed_hal/crc/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) 2021 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../MCU-Driver-HAL CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../.mbedbuild CACHE INTERNAL "")
+
+set(TEST_TARGET sdfx-st-test-crc)
+set(TEST_TARGET_LIB sdfx-test-crc)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(../../../.. ./MCU-Driver-ST)
+
+add_executable(${TEST_TARGET})
+
+mbed_configure_app_target(${TEST_TARGET})
+
+project(${TEST_TARGET})
+
+target_link_libraries(${TEST_TARGET}
+    PRIVATE
+        ${TEST_TARGET_LIB}
+)
+
+mbed_set_post_build(${TEST_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()


### PR DESCRIPTION
This PR enables the CRC greentea test. The test can be built and run with the existing steps in README.

Accompanies https://github.com/MCU-Driver-HAL/MCU-Driver-HAL/pull/12, to be merged after #12.