### PR TITLE
Follow us ticker updates from HAL repo

### DIFF
--- a/sdfx_st/examples/interrupt/README.md
+++ b/sdfx_st/examples/interrupt/README.md
@@ -1,3 +1,0 @@
-# Shadowfax Interrupt example
-
-See details about the application in `MCU-Driver-HAL/examples/interrupt/`.

--- a/sdfx_st/examples/us_ticker/README.md
+++ b/sdfx_st/examples/us_ticker/README.md
@@ -1,3 +1,0 @@
-# Shadowfax Micro Ticker example
-
-See details about the application in `MCU-Driver-HAL/examples/us_ticker/`.

--- a/sdfx_st/examples/us_ticker_delay/CMakeLists.txt
+++ b/sdfx_st/examples/us_ticker_delay/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../MCU-Driver-HAL CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../.mbedbuild CACHE INTERNAL "")
-set(APP_TARGET sdfx-st-hal-example-us_ticker)
+set(APP_TARGET sdfx-st-hal-example-us_ticker_delay)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
@@ -19,7 +19,7 @@ project(${APP_TARGET})
 
 target_link_libraries(${APP_TARGET}
     PRIVATE
-        sdfx-hal-example-us_ticker
+        sdfx-hal-example-us_ticker_delay
 )
 
 mbed_set_post_build(${APP_TARGET})

--- a/sdfx_st/examples/us_ticker_delay/README.md
+++ b/sdfx_st/examples/us_ticker_delay/README.md
@@ -1,0 +1,3 @@
+# Shadowfax Micro Ticker example
+
+See details about the application in `MCU-Driver-HAL/examples/us_ticker_delay/`.

--- a/sdfx_st/examples/us_ticker_interrupt/CMakeLists.txt
+++ b/sdfx_st/examples/us_ticker_interrupt/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
 
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../MCU-Driver-HAL CACHE INTERNAL "")
 set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../.mbedbuild CACHE INTERNAL "")
-set(APP_TARGET sdfx-st-hal-example-interrupt)
+set(APP_TARGET sdfx-st-hal-example-us_ticker_interrupt)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
@@ -19,7 +19,7 @@ project(${APP_TARGET})
 
 target_link_libraries(${APP_TARGET}
     PRIVATE
-        sdfx-hal-example-interrupt
+        sdfx-hal-example-us_ticker_interrupt
 )
 
 mbed_set_post_build(${APP_TARGET})

--- a/sdfx_st/examples/us_ticker_interrupt/README.md
+++ b/sdfx_st/examples/us_ticker_interrupt/README.md
@@ -1,0 +1,3 @@
+# Shadowfax Interrupt example
+
+See details about the application in `MCU-Driver-HAL/examples/us_ticker_interrupt/`.


### PR DESCRIPTION
This patch depends on https://github.com/MCU-Driver-HAL/MCU-Driver-HAL/pull/13 and brings the following updates:

- removal of `MCU-Driver-HAL/hal/include/hal/ticker_api.h`, an mbed-os specific middleware -- no changes for this repo; only a submodule reference to the HAL repo,
- renaming of 2 examples -- CMake file updates:
    - `interrupt` -> `us_ticker_interrupt`,
    - `us_ticker` -> `us_ticker_delay`.