### PR TITLE
Closes #6 and #7: Docs changes for an easier start, and to remove reliance on Ninja

### DIFF
--- a/sdfx_st/examples/README.md
+++ b/sdfx_st/examples/README.md
@@ -11,17 +11,19 @@ Each application can be built by doing the following:
     ```
     git clone --recursive https://github.com/MCU-Driver-HAL/MCU-Driver-ST
     ```
-1. Change the current working directory to `MCU-Driver-ST/sdfx_st/examples/<INTERFACE>/`
+1. Change the current working directory to `MCU-Driver-ST/sdfx_st/examples/<INTERFACE>/` with `<INTERFACE>` being the example for the API you want to run, eg `gpio`.
 1. Run:
     ```
     cmake -S . -B cmake_build -GNinja -DCMAKE_BUILD_TYPE=debug -DMBED_TOOLCHAIN=<TOOLCHAIN>
     ```
+    If you are using a non-default build system, and you have not set the environment variable, then you can append `-G<BuildSystem>` to the command above.
+    Possible values for `<TOOLCHAIN>` are `ARM` and `GCC_ARM`. More on that [here.](https://github.com/MCU-Driver-HAL/MCU-Driver-HAL/blob/main/docs/user/README.md#Compiler)
 1. Change the current working directory to `MCU-Driver-ST/sdfx_st/examples/<INTERFACE>/cmake_build/`
 1. Run:
     ```
     cmake --build .
     ```
-    
+
 Outcome: The application compiles, links and produces artefacts.
 
 # Program the artefact

--- a/sdfx_st/tests/README.md
+++ b/sdfx_st/tests/README.md
@@ -21,7 +21,8 @@ Each test can be built by doing the following:
     cmake -S ./ -B cmake_build/ -GNinja -DGREENTEA_CLIENT_STDIO=OFF -DMBED_TOOLCHAIN=<TOOLCHAIN> -DCMAKE_BUILD_TYPE=debug
     ```
 
-    If you prefer to use UNIX Makefiles rather than the Ninja build system, remove `-GNinja` from the command above.
+    If you are using a non-default build system, and you have not set the environment variable, then you can append `-G<BuildSystem>` to the command above.
+    Possible values for `<TOOLCHAIN>` are `ARM` and `GCC_ARM`. More on that [here.](https://github.com/MCU-Driver-HAL/MCU-Driver-HAL/blob/main/docs/user/README.md#Compiler)
 1. Build:
 
     ```


### PR DESCRIPTION
Changed the docs in the examples and test folders to:
Explain the options for the toolchain, and link back to the getting started doc for more information.
Get rid of using ninja as the default, and include some information to help if they're using a non standard build system.

Made the readme slightly clearer.

One of the links in here (theoretically) links to a page only created in the sibling PR on the MCU-Driver-HAL repo