### PR TITLE
Added support for the pwm example application

### DIFF
--- a/TARGET_STM32L4/CMakeLists.txt
+++ b/TARGET_STM32L4/CMakeLists.txt
@@ -15,7 +15,7 @@ target_sources(mbed-stm32l4
         flash_api.c
         # gpio_irq_device.c
         # i2c_device.c
-        # pwmout_device.c
+        pwmout_device.c
         serial_device.c
         spi_api.c
 )

--- a/sdfx_st/examples/README.md
+++ b/sdfx_st/examples/README.md
@@ -14,7 +14,7 @@ Each application can be built by doing the following:
 1. Change the current working directory to `MCU-Driver-ST/sdfx_st/examples/<INTERFACE>/` with `<INTERFACE>` being the example for the API you want to run, eg `gpio`.
 1. Run:
     ```
-    cmake -S . -B cmake_build -GNinja -DCMAKE_BUILD_TYPE=debug -DMBED_TOOLCHAIN=<TOOLCHAIN>
+    cmake -S . -B cmake_build -DCMAKE_BUILD_TYPE=debug -DMBED_TOOLCHAIN=<TOOLCHAIN>
     ```
     If you are using a non-default build system, and you have not set the environment variable, then you can append `-G<BuildSystem>` to the command above.
     Possible values for `<TOOLCHAIN>` are `ARM` and `GCC_ARM`. More on that [here.](https://github.com/MCU-Driver-HAL/MCU-Driver-HAL/blob/main/docs/user/README.md#Compiler)

--- a/sdfx_st/examples/pwm/CMakeLists.txt
+++ b/sdfx_st/examples/pwm/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../MCU-Driver-HAL CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET sdfx-st-hal-example-pwm)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(../../.. ./MCU-Driver-ST)
+
+add_executable(${APP_TARGET})
+
+mbed_configure_app_target(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        sdfx-hal-example-pwm
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/sdfx_st/examples/pwm/README.md
+++ b/sdfx_st/examples/pwm/README.md
@@ -1,0 +1,3 @@
+# Shadowfax PWM example
+
+See details about the application in `MCU-Driver-HAL/examples/pwm/`.

--- a/sdfx_st/hal/CMakeLists.txt
+++ b/sdfx_st/hal/CMakeLists.txt
@@ -24,7 +24,7 @@ target_sources(sdfx-hal-st
         src/ospi_api.c
         src/pinmap.c
         # src/port_api.c
-        # src/pwmout_api.c
+        src/pwmout_api.c
         # src/qspi_api.c
         # src/reset_reason.c
         # src/rtc_api.c

--- a/sdfx_st/hal/src/pwmout_api.c
+++ b/sdfx_st/hal/src/pwmout_api.c
@@ -33,6 +33,7 @@
 
 #include "cmsis.h"
 #include "pinmap.h"
+#include "mbed_assert.h"
 #include "mbed_error.h"
 #include "PeripheralPins.h"
 #include "pwmout_device.h"

--- a/sdfx_st/tests/README.md
+++ b/sdfx_st/tests/README.md
@@ -18,7 +18,7 @@ Each test can be built by doing the following:
 1. Generate the build system files:
 
     ```
-    cmake -S ./ -B cmake_build/ -GNinja -DGREENTEA_CLIENT_STDIO=OFF -DMBED_TOOLCHAIN=<TOOLCHAIN> -DCMAKE_BUILD_TYPE=debug
+    cmake -S ./ -B cmake_build/ -DGREENTEA_CLIENT_STDIO=OFF -DMBED_TOOLCHAIN=<TOOLCHAIN> -DCMAKE_BUILD_TYPE=debug
     ```
 
     If you are using a non-default build system, and you have not set the environment variable, then you can append `-G<BuildSystem>` to the command above.


### PR DESCRIPTION
Re-enabled the pwm libraries in TARGET_STM32L4's CMakeLists.txt and sdfc/hal/CMakeLists.txt.
Added a line to include mbed_assert.h to pwmout_api.c
Added a CMakeLists.txt to the examples folder to build it and a readme.me for the same folder.

Currently a draft as I need to update the MCU-Driver-HAL submodule to a commit that contains the pwm example and it hasn't been merged yet.

Signed-off-by: James Campbell <james.campbell2@arm.com>