### PR TITLE
Added support for the analogin example

### DIFF
--- a/TARGET_STM32L4/CMakeLists.txt
+++ b/TARGET_STM32L4/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(mbed-stm32l4 INTERFACE)
 
 target_sources(mbed-stm32l4
     INTERFACE
-        # analogin_device.c
+        analogin_device.c
         # analogout_device.c
         flash_api.c
         gpio_irq_device.c

--- a/sdfx_st/examples/analogin/CMakeLists.txt
+++ b/sdfx_st/examples/analogin/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../MCU-Driver-HAL CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET sdfx-st-hal-example-analogin)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(../../.. ./MCU-Driver-ST)
+
+add_executable(${APP_TARGET})
+
+mbed_configure_app_target(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        sdfx-hal-example-analogin
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/sdfx_st/examples/analogin/README.md
+++ b/sdfx_st/examples/analogin/README.md
@@ -1,0 +1,3 @@
+# Shadowfax analogin example
+
+See details about the application in `MCU-Driver-HAL/examples/analogin/`.

--- a/sdfx_st/hal/CMakeLists.txt
+++ b/sdfx_st/hal/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(sdfx-hal-st
 target_sources(sdfx-hal-st
     INTERFACE
         # src/USBPhy_STM32.cpp
-        # src/analogin_api.c
+        src/analogin_api.c
         # src/analogout_api.c
         # src/can_api.c
         src/gpio_api.c


### PR DESCRIPTION
Added folder with a readme and CMakeLists.txt for the example.
Enabled the libraries that are required.

Cannot be merged until the sibling commit is merged to the HAL repo and the submodule can be updated, and Hugues fix is merged.

Depends on:

- https://github.com/MCU-Driver-HAL/MCU-Driver-HAL/pull/50
- https://github.com/MCU-Driver-HAL/MCU-Driver-ST/pull/19

Signed-off-by: James Campbell <james.campbell2@arm.com>