### PR TITLE
crc example added to sdfx_st/examples

### DIFF
--- a/sdfx_st/examples/crc/CMakeLists.txt
+++ b/sdfx_st/examples/crc/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../MCU-Driver-HAL CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET sdfx-st-hal-example-crc)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(../../.. ./MCU-Driver-ST)
+
+add_executable(${APP_TARGET})
+
+mbed_configure_app_target(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        sdfx-hal-example-crc
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/sdfx_st/examples/crc/README.md
+++ b/sdfx_st/examples/crc/README.md
@@ -1,0 +1,3 @@
+# Shadowfax crc example
+
+See details about the application in `MCU-Driver-HAL/examples/crc/`.


### PR DESCRIPTION
Added a README and CMakeLists.txt to /sdfx_examples/crc.
Enabled the libraries that are required.

Cannot be merged until the sibling commit is merged to the HAL repo and the submodule can be updated, and Hugues' fix is merged.

Depends on:
https://github.com/MCU-Driver-HAL/MCU-Driver-HAL/pull/52
https://github.com/MCU-Driver-HAL/MCU-Driver-ST/pull/19


Signed-off-by: Liam Gallagher <Liam.Gallagher@arm.com>